### PR TITLE
Disable cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ app.get('/npm/*', packageNameMiddleware, async function (req, res, next) {
     .then((pkg) => {
       const { mode } = req.query;
       res.type('image/png');
+      res.set('Cache-Control', 'no-cache, no-store');
       drawBadge(pkg, parseInstallMode(mode)).pipe(res);
     })
     .catch(next);


### PR DESCRIPTION
So apparently GitHub instructs clients to cache images for 1 year. Kinda defeats the point of the nice stats in the badge.

Theoretically, settings  the cache headers on the origin will influence the cache. But I had no way of testing it.